### PR TITLE
fixing wrong git repo reference in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ init:
 	@git submodule update
 
 initrepo:
-	@git remote add upstream git://github.com/dkirker/macaw-enyo.git
+	@git remote add upstream git://github.com/minego/macaw-enyo.git
 
 initzip:
 	@mkdir -p lib
@@ -147,4 +147,3 @@ macaw-device.bar: bar
 bb10: bar
 
 .PHONY: clean webos install launch log test release apk ipk android bar
-


### PR DESCRIPTION
The upstream repository reference in the Makerfile is wrong. I fixed it to point to git://github.com/minego/macaw-enyo.git
