### PR TITLE
added a new Makefile rule to publish redirectpages to gh-pages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,9 @@ init:
 initrepo:
 	@git remote add upstream git://github.com/dkirker/macaw-enyo.git
 
+publishredirects:
+	@git subtree push --prefix redirectpages origin gh-pages
+
 initzip:
 	@mkdir -p lib
 	@curl -O https://codeload.github.com/enyojs/enyo/zip/master
@@ -147,4 +150,3 @@ macaw-device.bar: bar
 bb10: bar
 
 .PHONY: clean webos install launch log test release apk ipk android bar
-


### PR DESCRIPTION
This adds a new rule to the Makefile that enables you to issue

``` bash
$ make publishredirects
```

And push the contents of **redirectpages** to **gh-pages** thus making it available on the web and thus able to be used as redirect URLs for the OAuth 1.0a cycle.
